### PR TITLE
[DSEP-191] Support for Raspbian Bullseye

### DIFF
--- a/install_python_deps.sh
+++ b/install_python_deps.sh
@@ -19,26 +19,40 @@ if [[ "$OSTYPE" == "linux-gnu" ]]; then
 	exit 0 ||
 	echo -e "${RED}An issue was encountered when installing the python dependencies.${NC}" &&
 	exit 1
+	
 # Raspberry Pi Dependencies
 elif [[ "$OSTYPE" == "linux-gnueabihf" ]]; then
-	sudo apt-get update &&
-	sudo apt-get update
-	sudo apt-get install -y build-essential tk-dev libncurses5-dev libncursesw5-dev libreadline6-dev libdb5.3-dev libgdbm-dev libsqlite3-dev libssl-dev libbz2-dev libexpat1-dev liblzma-dev zlib1g-dev libffi-dev
-	wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
-	tar xf Python-3.9.0.tar.xz && cd Python-3.9.0  || exit 1
-	./configure --prefix=/usr/local/opt/python-3.9.0 && make -j &&
-	sudo make altinstall
-	cd .. && sudo rm -r Python-3.9.0 && rm Python-3.9.0.tar.xz
-	# shellcheck source=/dev/null
-	. "${HOME}"/.bashrc
-	sudo update-alternatives --config python
-	sudo apt-get install ufw python-scipy libatlas-base-dev -y &&
-	sudo ufw enable && sudo ufw allow 8988 && sudo ufw allow 22 && # Open port for graph display
-	add_user_to_dialout &&
-	echo -e "${GREEN}Python dependencies installed.${NC}" &&
-	exit 0 ||
-	echo -e "${RED}An issue was encountered when installing the python dependencies.${NC}" &&
-	exit 1
+	if cat /etc/os-release | grep "bullseye"; then
+		# Skipping Python 3.9.0 installation, since Bullseye is bundled with Python 3.9.2
+		sudo apt-get update &&
+		sudo apt-get install ufw python3-scipy libatlas-base-dev -y &&
+		sudo ufw --force enable && sudo ufw allow 8988 && sudo ufw allow 22 && # Open port for graph display
+		add_user_to_dialout &&
+		echo -e "${GREEN}Python dependencies installed.${NC}" &&
+		exit 0 ||
+		echo -e "${RED}An issue was encountered when installing the python dependencies.${NC}" &&
+		exit 1
+		
+	else
+		sudo apt-get update &&
+		sudo apt-get update
+		sudo apt-get install -y build-essential tk-dev libncurses5-dev libncursesw5-dev libreadline6-dev libdb5.3-dev libgdbm-dev libsqlite3-dev libssl-dev libbz2-dev libexpat1-dev liblzma-dev zlib1g-dev libffi-dev
+		wget https://www.python.org/ftp/python/3.9.0/Python-3.9.0.tar.xz
+		tar xf Python-3.9.0.tar.xz && cd Python-3.9.0  || exit 1
+		./configure --prefix=/usr/local/opt/python-3.9.0 && make -j &&
+		sudo make altinstall
+		cd .. && sudo rm -r Python-3.9.0 && rm Python-3.9.0.tar.xz
+		# shellcheck source=/dev/null
+		. "${HOME}"/.bashrc
+		sudo update-alternatives --config python
+		sudo apt-get install ufw python-scipy libatlas-base-dev -y &&
+		sudo ufw enable && sudo ufw allow 8988 && sudo ufw allow 22 && # Open port for graph display
+		add_user_to_dialout &&
+		echo -e "${GREEN}Python dependencies installed.${NC}" &&
+		exit 0 ||
+		echo -e "${RED}An issue was encountered when installing the python dependencies.${NC}" &&
+		exit 1
+	fi
 else
 	echo -e "${RED}Unsuported OS $OSTYPE. Nothing was installed.${NC}" &&
 	exit 1


### PR DESCRIPTION
# Description

Modified installation of python dependencies for [Raspbian Bullseye](https://www.raspberrypi.com/news/raspberry-pi-os-debian-bullseye/).

# Requirements
Edit the list accordingly.
- [ ] Tested on Windows.
- [ ] Tested on Linux.
- [x] Tested on RPi.
- [ ] Connected ActPack and runs scripts.
